### PR TITLE
Update beat bundle content and file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ build_all_apps: clean ## Clean, builds then packages all elastic beats binaries
 	@gox -arch="amd64 arm" -os="linux windows freebsd openbsd" -osarch="darwin/amd64" -output="bin/{{.OS}}_{{.Arch}}/eventsapibeat" -ldflags "-s $(VERSION_LDFLAGS)" .
 	@for d in bin/*/; do cp -a eventsapibeat-sample.yml $${d}; cp -a logstash-sample.conf $${d}; done
 	@cd bin && for d in */; do \
-  		COPYFILE_DISABLE=1 tar --exclude='.DS_Store' --exclude='.gitignore' --exclude='.travis.yml' -cvzf "$${d%/}.tar.gz" $${d}; \
+  		COPYFILE_DISABLE=1 tar --exclude='.DS_Store' --exclude='.gitignore' --exclude='.travis.yml' -cvzf "eventsapibeat_$(VERSION)_$${d%/}.tar.gz" $${d}; \
   		rm -rf $${d}; \
   	done


### PR DESCRIPTION
This PR brings back the file `eventsapibeat-sample.yml` into the `tar.gz` beat bundles and makes the bundles filenames more meaningful by adding a trailing `eventsapibeat_X.Y.Z` string on them:  

```
eventsapibeat_1.0.0_darwin_amd64.tar.gz
eventsapibeat_1.0.0_freebsd_amd64.tar.gz
eventsapibeat_1.0.0_freebsd_arm.tar.gz
eventsapibeat_1.0.0_linux_amd64.tar.gz
eventsapibeat_1.0.0_linux_arm.tar.gz
eventsapibeat_1.0.0_openbsd_amd64.tar.gz
eventsapibeat_1.0.0_windows_amd64.tar.gz
```