### PR TITLE
use source.ip instead of host.ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Elastic Common Schema
 | `user.email`                          | The email address of the user, hydrated at the time the event was generated                                                                               |
 | `os.name`                             | The name of the operating system of the user that attempted to sign in to the account                                                                     |
 | `os.version`                          | The version of the operating system of the user that attempted to sign in to the account                                                                  |
-| `host.ip`                             | The IP address that attempted to sign in to the account                                                                                                   |
+| `source.ip`                             | The IP address that attempted to sign in to the account                                                                                                   |
 | `onepassword.uuid`                    | The UUID of the event                                                                                                                                     |
 | `onepassword.session_uuid`            | The UUID of the session that created the event                                                                                                            |
 | `onepassword.type`                    | Details about the sign-in attempt                                                                                                                         |
@@ -72,7 +72,7 @@ Elastic Common Schema
 | `user.email`                          | The email address of the user, hydrated at the time the event was generated                                                                               |
 | `os.name`                             | The name of the operating system the item was accessed from                                                                                               |
 | `os.version`                          | The version of the operating system the item was accessed from                                                                                            |
-| `host.ip`                             | The IP address the item was accessed from                                                                                                                 |
+| `source.ip`                             | The IP address the item was accessed from                                                                                                                 |
 | `onepassword.uuid`                    | The UUID of the event                                                                                                                                     |
 | `onepassword.used_version`            | The version of the item that was accessed                                                                                                                 |
 | `onepassword.vault_uuid`              | The UUID of the vault the item is in                                                                                                                      |

--- a/api/ecs.go
+++ b/api/ecs.go
@@ -29,7 +29,7 @@ func (i *SignInAttempt) BeatEvent() *beat.Event {
 				Name:    i.SignInAttemptClient.OSName,
 				Version: i.SignInAttemptClient.OSVersion,
 			},
-			"host": ECSHost{
+			"source": ECSHost{
 				IP: i.SignInAttemptClient.IPAddress,
 			},
 			CustomFieldSet: common.MapStr{
@@ -64,7 +64,7 @@ func (i *ItemUsage) BeatEvent() *beat.Event {
 				Name:    i.ItemUsageClient.OSName,
 				Version: i.ItemUsageClient.OSVersion,
 			},
-			"host": ECSHost{
+			"source": ECSHost{
 				IP: i.ItemUsageClient.IPAddress,
 			},
 			CustomFieldSet: common.MapStr{


### PR DESCRIPTION
It's better to use source.ip instead of host.ip for the following reasons:
- Elastic references source.ip in much of their builtin Security detections.
- host.ip usually indicates a server.