### PR TITLE
Resolve eachers dependency to its canonical repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,11 @@ require (
 // Please read the following links for more information:
 // https://github.com/elastic/beats/issues/21188
 // https://www.elastic.co/guide/en/beats/devguide/current/newbeat-migrate-gomodules.html#newbeat-migrate-gomodules
+// The github.com/poy/eachers replacement is an addition in this repository
 replace (
 	github.com/Microsoft/go-winio => github.com/bi-zone/go-winio v0.4.15
 	github.com/Shopify/sarama => github.com/elastic/sarama v1.19.1-0.20210120173147-5c8cb347d877
+	github.com/apoydence/eachers => github.com/poy/eachers v0.0.0-20181020210610-23942921fe77 // GitHub user renamed
 	github.com/containerd/containerd => github.com/containerd/containerd v1.4.11
 	github.com/cucumber/godog => github.com/cucumber/godog v0.8.1
 	github.com/docker/docker => github.com/docker/engine v0.0.0-20191113042239-ea84732a7725

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,6 @@ github.com/andrewkroh/sys v0.0.0-20151128191922-287798fe3e43/go.mod h1:tJPYQG4mn
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antlr/antlr4 v0.0.0-20200820155224-be881fa6b91d/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
 github.com/apache/thrift v0.13.1-0.20200603211036-eac4d0c79a5f/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apoydence/eachers v0.0.0-20181020210610-23942921fe77/go.mod h1:bXvGk6IkT1Agy7qzJ+DjIw/SJ1AaB3AvAuMDVV+Vkoo=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -494,6 +493,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/poy/eachers v0.0.0-20181020210610-23942921fe77/go.mod h1:x1vqpbcMW9T/KRcQ4b48diSiSVtYgvwQ5xzDByEg4WE=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -847,6 +847,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/Microsoft/go-winio => github.com/bi-zone/go-winio v0.4.15
 # github.com/Shopify/sarama => github.com/elastic/sarama v1.19.1-0.20210120173147-5c8cb347d877
+# github.com/apoydence/eachers => github.com/poy/eachers v0.0.0-20181020210610-23942921fe77
 # github.com/containerd/containerd => github.com/containerd/containerd v1.4.11
 # github.com/cucumber/godog => github.com/cucumber/godog v0.8.1
 # github.com/docker/docker => github.com/docker/engine v0.0.0-20191113042239-ea84732a7725
@@ -859,4 +860,3 @@ sigs.k8s.io/yaml
 # github.com/insomniacslk/dhcp => github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3
 # github.com/tonistiigi/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
 # golang.org/x/tools => golang.org/x/tools v0.0.0-20200602230032-c00d67ef29d0
-# github.com/apoydence/eachers => github.com/poy/eachers v0.0.0-20181020210610-23942921fe77

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -859,3 +859,4 @@ sigs.k8s.io/yaml
 # github.com/insomniacslk/dhcp => github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3
 # github.com/tonistiigi/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
 # golang.org/x/tools => golang.org/x/tools v0.0.0-20200602230032-c00d67ef29d0
+# github.com/apoydence/eachers => github.com/poy/eachers v0.0.0-20181020210610-23942921fe77


### PR DESCRIPTION
Some time ago, the transient dependency github.com/apoydence/eachers changed to being at github.com/poy/eachers . 
 
This MR resolves that transient dependency to the new upstream. This prevents anyone from grabbing the available GitHub name and potentially inserting bad things in that dependency. Even though GitHub still redirects users going to the old repository to new one, if someone creates a new dependency at the old location they will be able to (try to) get our dependencies in here.