### PR TITLE
Includes Geolocation data for both Item Usages and Sign In Attempts Events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 2.2.0
+VERSION := 2.3.0
 VERSION_LDFLAGS="-X=go.1password.io/eventsapibeat/version.Version=$(VERSION)"
 
 .PHONY: eventsapibeat

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Elastic Common Schema
 | `geo.country_iso_code`                | The country code of the event. Uses the ISO 3166 standard                                                                                                 | keyword   |
 | `geo.region_name`                     | The region name of the event                                                                                                                              | keyword   |
 | `geo.city_name`                       | The city name of the event                                                                                                                                | keyword   |
-| `geo.location`                        | The longitutde and latitude of the event                                                                                                                  | geo_point |
+| `geo.location`                        | The longitude and latitude of the event                                                                                                                   | geo_point |
 | `onepassword.uuid`                    | The UUID of the event                                                                                                                                     | keyword   |
 | `onepassword.session_uuid`            | The UUID of the session that created the event                                                                                                            | keyword   |
 | `onepassword.type`                    | Details about the sign-in attempt                                                                                                                         | keyword   |

--- a/README.md
+++ b/README.md
@@ -42,43 +42,51 @@ Elastic Common Schema
 
 ### Sign-in Attempts fields
 
-| Field                                 | Description                                                                                                                                               | Type    |
-|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `@timestamp`                          | The date and time of the sign-in attempt                                                                                                                  | date    |
-| `event.action`                        | The category of the sign-in attempt                                                                                                                       | keyword |
-| `user.id`                             | The UUID of the user that attempted to sign in to the account                                                                                             | keyword |
-| `user.full_name`                      | The name of the user, hydrated at the time the event was generated                                                                                        | keyword |
-| `user.email`                          | The email address of the user, hydrated at the time the event was generated                                                                               | keyword |
-| `os.name`                             | The name of the operating system of the user that attempted to sign in to the account                                                                     | keyword |
-| `os.version`                          | The version of the operating system of the user that attempted to sign in to the account                                                                  | keyword |
-| `source.ip`                           | The IP address that attempted to sign in to the account                                                                                                   | ip      |
-| `onepassword.uuid`                    | The UUID of the event                                                                                                                                     | keyword |
-| `onepassword.session_uuid`            | The UUID of the session that created the event                                                                                                            | keyword |
-| `onepassword.type`                    | Details about the sign-in attempt                                                                                                                         | keyword |
-| `onepassword.country`                 | The country code of the event. Uses the ISO 3166 standard                                                                                                 | keyword |
-| `onepassword.details`                 | Additional information about the sign-in attempt, such as any firewall rules that prevent a user from signing in                                          | keyword |
-| `onepassword.client.app_name`         | The name of the 1Password app that attempted to sign in to the account                                                                                    | keyword |
-| `onepassword.client.app_version`      | The version number of the 1Password app                                                                                                                   | keyword |
-| `onepassword.client.platform_name`    | The name of the platform running the 1Password app                                                                                                        | keyword |
-| `onepassword.client.platform_version` | The version of the browser or computer where the 1Password app is installed, or the CPU of the machine where the 1Password command-line tool is installed | keyword |
+| Field                                 | Description                                                                                                                                               | Type      |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `@timestamp`                          | The date and time of the sign-in attempt                                                                                                                  | date      |
+| `event.action`                        | The category of the sign-in attempt                                                                                                                       | keyword   |
+| `user.id`                             | The UUID of the user that attempted to sign in to the account                                                                                             | keyword   |
+| `user.full_name`                      | The name of the user, hydrated at the time the event was generated                                                                                        | keyword   |
+| `user.email`                          | The email address of the user, hydrated at the time the event was generated                                                                               | keyword   |
+| `os.name`                             | The name of the operating system of the user that attempted to sign in to the account                                                                     | keyword   |
+| `os.version`                          | The version of the operating system of the user that attempted to sign in to the account                                                                  | keyword   |
+| `source.ip`                           | The IP address that attempted to sign in to the account                                                                                                   | ip        |
+| `geo.country_iso_code`                | The country code of the event. Uses the ISO 3166 standard                                                                                                 | keyword   |
+| `geo.region_name`                     | The region name of the event                                                                                                                              | keyword   |
+| `geo.city_name`                       | The city name of the event                                                                                                                                | keyword   |
+| `geo.location`                        | The longitutde and latitude of the event                                                                                                                  | geo_point |
+| `onepassword.uuid`                    | The UUID of the event                                                                                                                                     | keyword   |
+| `onepassword.session_uuid`            | The UUID of the session that created the event                                                                                                            | keyword   |
+| `onepassword.type`                    | Details about the sign-in attempt                                                                                                                         | keyword   |
+| `onepassword.country`                 | The country code of the event. Uses the ISO 3166 standard                                                                                                 | keyword   |
+| `onepassword.details`                 | Additional information about the sign-in attempt, such as any firewall rules that prevent a user from signing in                                          | keyword   |
+| `onepassword.client.app_name`         | The name of the 1Password app that attempted to sign in to the account                                                                                    | keyword   |
+| `onepassword.client.app_version`      | The version number of the 1Password app                                                                                                                   | keyword   |
+| `onepassword.client.platform_name`    | The name of the platform running the 1Password app                                                                                                        | keyword   |
+| `onepassword.client.platform_version` | The version of the browser or computer where the 1Password app is installed, or the CPU of the machine where the 1Password command-line tool is installed | keyword   |
 
 ### Item Usages fields
 
-| Field                                 | Description                                                                                                                                               | Type    |
-|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `@timestamp`                          | The date and time of the item usage                                                                                                                       | date    |
-| `event.action`                        | The action performed on the item                                                                                                                          | keyword |
-| `user.id`                             | The UUID of the user that accessed the item                                                                                                               | keyword |
-| `user.full_name`                      | The name of the user, hydrated at the time the event was generated                                                                                        | keyword |
-| `user.email`                          | The email address of the user, hydrated at the time the event was generated                                                                               | keyword |
-| `os.name`                             | The name of the operating system the item was accessed from                                                                                               | keyword |
-| `os.version`                          | The version of the operating system the item was accessed from                                                                                            | keyword |
-| `source.ip`                           | The IP address the item was accessed from                                                                                                                 | ip      |
-| `onepassword.uuid`                    | The UUID of the event                                                                                                                                     | keyword |
-| `onepassword.used_version`            | The version of the item that was accessed                                                                                                                 | long    |
-| `onepassword.vault_uuid`              | The UUID of the vault the item is in                                                                                                                      | keyword |
-| `onepassword.item_uuid`               | The UUID of the item that was accessed                                                                                                                    | keyword |
-| `onepassword.client.app_name`         | The name of the 1Password app the item was accessed from                                                                                                  | keyword |
-| `onepassword.client.app_version`      | The version number of the 1Password app                                                                                                                   | keyword |
-| `onepassword.client.platform_name`    | The name of the platform the item was accessed from                                                                                                       | keyword |
-| `onepassword.client.platform_version` | The version of the browser or computer where the 1Password app is installed, or the CPU of the machine where the 1Password command-line tool is installed | keyword |
+| Field                                 | Description                                                                                                                                               | Type      |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `@timestamp`                          | The date and time of the item usage                                                                                                                       | date      |
+| `event.action`                        | The action performed on the item                                                                                                                          | keyword   |
+| `user.id`                             | The UUID of the user that accessed the item                                                                                                               | keyword   |
+| `user.full_name`                      | The name of the user, hydrated at the time the event was generated                                                                                        | keyword   |
+| `user.email`                          | The email address of the user, hydrated at the time the event was generated                                                                               | keyword   |
+| `os.name`                             | The name of the operating system the item was accessed from                                                                                               | keyword   |
+| `os.version`                          | The version of the operating system the item was accessed from                                                                                            | keyword   |
+| `source.ip`                           | The IP address the item was accessed from                                                                                                                 | ip        |
+| `geo.country_iso_code`                | The country code of the event. Uses the ISO 3166 standard                                                                                                 | keyword   |
+| `geo.region_name`                     | The region name of the event                                                                                                                              | keyword   |
+| `geo.city_name`                       | The city name of the event                                                                                                                                | keyword   |
+| `geo.location`                        | The longitutde and latitude of the event                                                                                                                  | geo_point |
+| `onepassword.uuid`                    | The UUID of the event                                                                                                                                     | keyword   |
+| `onepassword.used_version`            | The version of the item that was accessed                                                                                                                 | long      |
+| `onepassword.vault_uuid`              | The UUID of the vault the item is in                                                                                                                      | keyword   |
+| `onepassword.item_uuid`               | The UUID of the item that was accessed                                                                                                                    | keyword   |
+| `onepassword.client.app_name`         | The name of the 1Password app the item was accessed from                                                                                                  | keyword   |
+| `onepassword.client.app_version`      | The version number of the 1Password app                                                                                                                   | keyword   |
+| `onepassword.client.platform_name`    | The name of the platform the item was accessed from                                                                                                       | keyword   |
+| `onepassword.client.platform_version` | The version of the browser or computer where the 1Password app is installed, or the CPU of the machine where the 1Password command-line tool is installed | keyword   |

--- a/api/api.go
+++ b/api/api.go
@@ -37,6 +37,7 @@ type SignInAttempt struct {
 	Details                 *SignInAttemptDetails   `json:"details"`
 	SignInAttemptTargetUser SignInAttemptTargetUser `json:"target_user"`
 	SignInAttemptClient     SignInAttemptClient     `json:"client"`
+	SignInAttemptLocation   *SignInAttemptLocation  `json:"location"`
 }
 
 type SignInAttemptDetails struct {
@@ -59,6 +60,14 @@ type SignInAttemptClient struct {
 	IPAddress       string `json:"ip_address"`
 }
 
+type SignInAttemptLocation struct {
+	Country   string  `json:"country"`
+	Region    string  `json:"region"`
+	City      string  `json:"city"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
 type ItemUsageResponse struct {
 	Cursor  string      `json:"cursor"`
 	HasMore bool        `json:"has_more"`
@@ -66,14 +75,15 @@ type ItemUsageResponse struct {
 }
 
 type ItemUsage struct {
-	UUID            string          `json:"uuid"`
-	Timestamp       time.Time       `json:"timestamp"`
-	UsedVersion     uint32          `json:"used_version"`
-	VaultUUID       string          `json:"vault_uuid"`
-	ItemUUID        string          `json:"item_uuid"`
-	Action          string          `json:"action"`
-	ItemUsageUser   ItemUsageUser   `json:"user"`
-	ItemUsageClient ItemUsageClient `json:"client"`
+	UUID              string             `json:"uuid"`
+	Timestamp         time.Time          `json:"timestamp"`
+	UsedVersion       uint32             `json:"used_version"`
+	VaultUUID         string             `json:"vault_uuid"`
+	ItemUUID          string             `json:"item_uuid"`
+	Action            string             `json:"action"`
+	ItemUsageUser     ItemUsageUser      `json:"user"`
+	ItemUsageClient   ItemUsageClient    `json:"client"`
+	ItemUsageLocation *ItemUsageLocation `json:"location"`
 }
 
 type ItemUsageUser struct {
@@ -90,6 +100,14 @@ type ItemUsageClient struct {
 	OSName          string `json:"os_name"`
 	OSVersion       string `json:"os_version"`
 	IPAddress       string `json:"ip_address"`
+}
+
+type ItemUsageLocation struct {
+	Country   string  `json:"country"`
+	Region    string  `json:"region"`
+	City      string  `json:"city"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
 }
 
 type IntrospectResponse struct {

--- a/api/ecs.go
+++ b/api/ecs.go
@@ -14,9 +14,9 @@ func (i *SignInAttempt) BeatEvent() *beat.Event {
 	if i.Details != nil {
 		details = i.Details
 	}
-	var geo interface{} = emptyMap
+	var geo *ECSGeo
 	if i.SignInAttemptLocation != nil {
-		geo = ECSGeo{
+		geo = &ECSGeo{
 			Country: i.SignInAttemptLocation.Country,
 			Region:  i.SignInAttemptLocation.Region,
 			City:    i.SignInAttemptLocation.City,
@@ -42,9 +42,9 @@ func (i *SignInAttempt) BeatEvent() *beat.Event {
 				Version: i.SignInAttemptClient.OSVersion,
 			},
 			"source": ECSSource{
-				IP: i.SignInAttemptClient.IPAddress,
+				IP:  i.SignInAttemptClient.IPAddress,
+				Geo: geo,
 			},
-			"geo": geo,
 			CustomFieldSet: common.MapStr{
 				"uuid":         i.UUID,
 				"session_uuid": i.SessionUUID,
@@ -65,9 +65,9 @@ func (i *SignInAttempt) BeatEvent() *beat.Event {
 }
 
 func (i *ItemUsage) BeatEvent() *beat.Event {
-	var geo interface{} = emptyMap
+	var geo *ECSGeo
 	if i.ItemUsageLocation != nil {
-		geo = ECSGeo{
+		geo = &ECSGeo{
 			Country: i.ItemUsageLocation.Country,
 			Region:  i.ItemUsageLocation.Region,
 			City:    i.ItemUsageLocation.City,
@@ -93,9 +93,9 @@ func (i *ItemUsage) BeatEvent() *beat.Event {
 				Version: i.ItemUsageClient.OSVersion,
 			},
 			"source": ECSSource{
-				IP: i.ItemUsageClient.IPAddress,
+				IP:  i.ItemUsageClient.IPAddress,
+				Geo: geo,
 			},
-			"geo": geo,
 			CustomFieldSet: common.MapStr{
 				"uuid":         i.UUID,
 				"used_version": i.UsedVersion,
@@ -130,7 +130,8 @@ type ECSOs struct {
 }
 
 type ECSSource struct {
-	IP string `json:"ip,omitempty" ecs:"ip"`
+	IP  string  `json:"ip,omitempty" ecs:"ip"`
+	Geo *ECSGeo `json:"geo,omitempty" ecs:"geo"`
 }
 
 type ECSGeo struct {

--- a/api/ecs.go
+++ b/api/ecs.go
@@ -14,6 +14,18 @@ func (i *SignInAttempt) BeatEvent() *beat.Event {
 	if i.Details != nil {
 		details = i.Details
 	}
+	var geo interface{} = emptyMap
+	if i.SignInAttemptLocation != nil {
+		geo = ECSGeo{
+			Country: i.SignInAttemptLocation.Country,
+			Region:  i.SignInAttemptLocation.Region,
+			City:    i.SignInAttemptLocation.City,
+			Location: ECSGeoPoint{
+				Latitude:  i.SignInAttemptLocation.Latitude,
+				Longitude: i.SignInAttemptLocation.Longitude,
+			},
+		}
+	}
 	e := &beat.Event{
 		Timestamp: i.Timestamp,
 		Fields: common.MapStr{
@@ -32,6 +44,7 @@ func (i *SignInAttempt) BeatEvent() *beat.Event {
 			"source": ECSSource{
 				IP: i.SignInAttemptClient.IPAddress,
 			},
+			"geo": geo,
 			CustomFieldSet: common.MapStr{
 				"uuid":         i.UUID,
 				"session_uuid": i.SessionUUID,
@@ -52,6 +65,18 @@ func (i *SignInAttempt) BeatEvent() *beat.Event {
 }
 
 func (i *ItemUsage) BeatEvent() *beat.Event {
+	var geo interface{} = emptyMap
+	if i.ItemUsageLocation != nil {
+		geo = ECSGeo{
+			Country: i.ItemUsageLocation.Country,
+			Region:  i.ItemUsageLocation.Region,
+			City:    i.ItemUsageLocation.City,
+			Location: ECSGeoPoint{
+				Latitude:  i.ItemUsageLocation.Latitude,
+				Longitude: i.ItemUsageLocation.Longitude,
+			},
+		}
+	}
 	e := &beat.Event{
 		Timestamp: i.Timestamp,
 		Fields: common.MapStr{
@@ -70,6 +95,7 @@ func (i *ItemUsage) BeatEvent() *beat.Event {
 			"source": ECSSource{
 				IP: i.ItemUsageClient.IPAddress,
 			},
+			"geo": geo,
 			CustomFieldSet: common.MapStr{
 				"uuid":         i.UUID,
 				"used_version": i.UsedVersion,
@@ -105,4 +131,16 @@ type ECSOs struct {
 
 type ECSSource struct {
 	IP string `json:"ip,omitempty" ecs:"ip"`
+}
+
+type ECSGeo struct {
+	Country  string      `json:"country_iso_code" ecs:"country_iso_code"`
+	Region   string      `json:"region_name" ecs:"region_name"`
+	City     string      `json:"city_name" ecs:"city_name"`
+	Location ECSGeoPoint `json:"location" ecs:"location"`
+}
+
+type ECSGeoPoint struct {
+	Latitude  float64 `json:"lat" ecs:"lat"`
+	Longitude float64 `json:"lon" ecs:"lon"`
 }


### PR DESCRIPTION
This PR adds a new `geo` fields with geolocation information for both item usages events and sign-in attempts events.

The new included fields are as follow:
```
geo.country_iso_code: The country code of the event. Uses the ISO 3166 standard
geo.region_name: The region name of the event
geo.city_name: The city name of the event
geo.location: The longitude and latitude of the event   
```

The beat version is bumped to 2.3.0 