### PR TITLE
Elasticbeat will retry on http errors before exiting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 2.3.0
+VERSION := 2.4.0
 VERSION_LDFLAGS="-X=go.1password.io/eventsapibeat/version.Version=$(VERSION)"
 
 .PHONY: eventsapibeat


### PR DESCRIPTION
This PR reduces the chance of the elasticbeat exiting, by doing two things:

- Increase the max retries on error
- Allow retry for http errors


The beat version is bumped to 2.4.0